### PR TITLE
Adding fine-tuning

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -4,21 +4,21 @@
 build:
   # set to true if your model requires a GPU
   gpu: true
-  cuda: "11.7"
+  cuda: "11.8"
 
   # python version in the form '3.8' or '3.8.12'
-  python_version: "3.8"
+  python_version: "3.11"
 
   # a list of packages in the format <package-name>==<version>
   python_packages:
-    - "numpy==1.24.2"
-    - "torch==2.0.0"
-    - "accelerate==0.18.0"
-    - "peft==0.2.0"
-    - "sentencepiece==0.1.97"
+    - "numpy==1.25.1"
+    - "torch==2.0.1"
+    - "accelerate==0.21.0"
+    - "peft==0.4.0"
+    - "sentencepiece==0.1.99"
     - "tensorizer==1.0.1"
     - "jinja2==3.1.2"
-    - "deepspeed==0.8.3"
+    - "deepspeed==0.10.0"
 
 
   run: 

--- a/llama_weights/tokenizer/tokenizer_config.json
+++ b/llama_weights/tokenizer/tokenizer_config.json
@@ -1,1 +1,1 @@
-{"bos_token": "", "eos_token": "", "model_max_length": 1000000000000000019884624838656, "tokenizer_class": "LlamaTokenizer", "unk_token": ""}
+{"bos_token": "", "eos_token": "", "model_max_length": 4096, "tokenizer_class": "LlamaTokenizer", "unk_token": ""}

--- a/train.py
+++ b/train.py
@@ -73,7 +73,7 @@ def train(
         input_weights = local_weights
 
     root_path = os.getcwd()
-    deepspeed_config = os.path.join(root_path, "ds_config/ds_z3_fp16_config.json")
+    deepspeed_config = os.path.join(root_path, "ds_config/ds_z3_bf16_config.json")
 
     output_dir = DIST_OUT_DIR
     if os.path.exists(output_dir):

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -204,7 +204,7 @@ def load_peft_model(
     print(f"LoRA config: {config}")
     model = get_peft_model(model, config)
     print_trainable_parameters(model)
-
+    model.config.use_cache = False # required for gradient checkpointing
     return model
 
 

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -170,6 +170,19 @@ def load_model(model_name_or_path):
     model = load_tensorizer(model_name_or_path, plaid_mode=False, cls=LlamaForCausalLM)
     return model
 
+def print_trainable_parameters(model):
+    """
+    Prints the number of trainable parameters in the model.
+    """
+    trainable_params = 0
+    all_param = 0
+    for _, param in model.named_parameters():
+        all_param += param.numel()
+        if param.requires_grad:
+            trainable_params += param.numel()
+    print(
+        f"trainable params: {trainable_params} || all params: {all_param} || trainable%: {100 * trainable_params / all_param}"
+    )
 
 def load_peft_model(
     model_name_or_path, lora_rank: int, lora_alpha: int, lora_dropout: float, lora_target_modules: Optional[Union[List[str], str]]
@@ -190,6 +203,8 @@ def load_peft_model(
     )
     print(f"LoRA config: {config}")
     model = get_peft_model(model, config)
+    print_trainable_parameters(model)
+
     return model
 
 

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -178,6 +178,7 @@ def load_peft_model(
         lora_target_modules = lora_target_modules.split(",")
     print("Using LoRA...")
     model = load_model(model_name_or_path)
+    model.gradient_checkpointing_enable()
         
     config = LoraConfig(
         r=lora_rank,
@@ -284,10 +285,11 @@ def train(
             learning_rate=learning_rate,
             max_steps=max_steps,
             tf32=True,
-            fp16=True,
+            bf16=True,
             half_precision_backend="cuda_amp",
             deepspeed=deepspeed,
-            local_rank=local_rank
+            local_rank=local_rank,
+            gradient_checkpointing=True
         ),
         data_collator=SequenceDataCollator(tokenizer, 8),  # depends on bf16 value
     )


### PR DESCRIPTION
This PR updates this script to enable lora fine-tuning of llama models. Changes:

- switched tuning to bf16
- added in gradient checkpointing
- included `max_length` for the tokenizer to truncate training inputs to the 4k context window
- Updated relevant packages + python version 