### PR TITLE
WIP: Eval checkpointing

### DIFF
--- a/cog.yaml
+++ b/cog.yaml
@@ -18,12 +18,12 @@ build:
     - "sentencepiece==0.1.99"
     - "tensorizer==1.0.1"
     - "jinja2==3.1.2"
-    - "deepspeed==0.10.0"
     - "transformers==4.31.0"
 
 
   run: 
     - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/download/v0.0.1/pget" && chmod +x /usr/local/bin/pget
+    - "pip install git+https://github.com/microsoft/DeepSpeed.git@777ae39a85988da3e934c272842f6c65686b8896"
     
 
 # predict.py defines how predictions are run on your model

--- a/cog.yaml
+++ b/cog.yaml
@@ -19,12 +19,10 @@ build:
     - "tensorizer==1.0.1"
     - "jinja2==3.1.2"
     - "deepspeed==0.10.0"
+    - "transformers==4.31.0"
 
 
   run: 
-    - "pip install git+https://github.com/huggingface/transformers.git@786092a35e18154cacad62c30fe92bac2c27a1e1"
-    - "mkdir /gc && cd /gc && curl -O https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-426.0.0-linux-x86_64.tar.gz && tar -xf google-cloud-cli-426.0.0-linux-x86_64.tar.gz && ./google-cloud-sdk/install.sh -q"
-    - "pip install google-cloud-storage"
     - curl -o /usr/local/bin/pget -L "https://github.com/replicate/pget/releases/download/v0.0.1/pget" && chmod +x /usr/local/bin/pget
     
 

--- a/train.py
+++ b/train.py
@@ -10,6 +10,7 @@ import torch
 from cog import BaseModel, Input, Path
 from tensorizer import TensorSerializer
 from transformers import LlamaForCausalLM
+import numpy as np
 
 from config import DEFAULT_MODEL_NAME, download_file
 
@@ -18,6 +19,15 @@ CHECKPOINT_DIR = "checkpoints"
 SAVE_STRATEGY = "epoch"
 DIST_OUT_DIR = "tmp/model"
 
+
+def sample_dataset(train_file, test_file, train_eval_split, train_file_out):
+    """Samples train dataset to create new train & eval datasets"""
+    with open(train_file, "r") as src, open(test_file, "w") as tst, open(train_file_out, "w") as trn:
+        for line in src:
+            if np.random.rand() < train_eval_split:  # move line to test.txt
+                trn.write(line)
+            else:  # keep in train.txt
+                tst.write(line)
 
 class TrainingOutput(BaseModel):
     weights: Path
@@ -70,7 +80,8 @@ def train(
     lora_dropout: float = Input(description="Dropout for lora training", default=0.1, ge=0.0, le=1.0),
     lora_target_modules: str = Input(description="Comma-separated list of lora modules to target, i.e. 'q_proj,v_proj'. Leave blank for default.", default="q_proj,v_proj"),
     save_strategy: str = Input(description="Whether to save a checkpoint of the model every n steps or every epoch. Only relevant if `eval_data` or `train_eval_split` are set.", default="epoch", choices=["epoch", "steps", "no"]),
-    save_steps: int = Input(description="Evaluate the performance of the model and save a checkpoint every `save_steps`. Has to be used with `save_strategy=steps`.", default=None, ge=1)
+    save_steps: int = Input(description="Evaluate the performance of the model and save a checkpoint every `save_steps`. Has to be used with `save_strategy=steps`.", default=None, ge=1),
+    seed: int = Input(description="Random seed for reproducibile training", default=None)
 ) -> TrainingOutput:
     input_weights = weights if weights is not None else DEFAULT_MODEL_NAME
 
@@ -88,13 +99,28 @@ def train(
         shutil.rmtree(output_dir)
     os.makedirs(output_dir)
 
-    # so what we need to do here, then, is determine flow
-    # if eval_set - great
-    # if no eval_set - split train set here UNLESS some flag is set not to
-    # save_strategy 
-    # return best_model is passed *unless* eval nothing 
-    # if nothing is passed then no checkpointing, etc. 
-    # so basically just go through assuming good stuff and then return bad stuff if absolutely needed. 
+    if seed is None:
+        seed = np.random.randint(0, 2**32-1)
+    print(f"Using random seed {seed}")
+    
+    # seeding numpy for reproducible train/test split if needed
+    np.random.seed(seed)
+
+    if not eval_data and train_eval_split < 1:
+        # need to do this here as opposed to in parallel workers - or rather this is the simplest way.
+        # probably faster to pass a deterministic partitioning function to `deepspeed`, can look into that if needed 
+        print(f"Sampling eval dataset from train dataset.")
+        new_train_data = '/src/local_train.jsonl'
+        eval_data = '/src/local_eval.jsonl'
+
+        sample_dataset(train_data, eval_data, train_eval_split, new_train_data)
+        print(f"Eval dataset generated.")
+        train_data = new_train_data
+
+    if eval_data:
+        # if we have evaluation data, we return the best model. 
+        evaluation_strategy = save_strategy
+        load_best_model_at_end = True
 
     num_gpus = torch.cuda.device_count()
     num_gpus_flag = f"--num_gpus={num_gpus}"
@@ -133,6 +159,8 @@ def train(
         + _arg_if_present(lora_target_modules, "lora_target_modules")
         + f" --save_strategy {save_strategy}"
         + f" --save_steps {save_steps}"
+        + f" --evaluation_strategy {evaluation_strategy}"
+        + f" --load_best_model_at_end {load_best_model_at_end}"
         + " --local_output_dir "
         + output_dir,
         shell=True,

--- a/training/patched_deepspeed_checkpoint.py
+++ b/training/patched_deepspeed_checkpoint.py
@@ -1,0 +1,22 @@
+
+
+def mod_deepspeed_load_checkpoint(deepspeed_engine, checkpoint_path):
+    # it's possible that the user is trying to resume from model_path, which doesn't necessarily
+    # contain a deepspeed checkpoint. e.g. examples just check if the dir exists and assume it's
+    # a resume from a checkpoint and not just a local pretrained weight. So we check here if the
+    # path contains what looks like a deepspeed checkpoint
+    import glob
+
+    deepspeed_checkpoint_dirs = sorted(glob.glob(f"{checkpoint_path}/global_step*"))
+
+    if len(deepspeed_checkpoint_dirs) > 0:
+        print(f"Attempting to resume from {checkpoint_path}")
+        print(f"modified!")
+        # this magically updates self.optimizer and self.lr_scheduler
+        load_path, _ = deepspeed_engine.load_checkpoint(
+            checkpoint_path, load_optimizer_states=True, load_lr_scheduler_states=True, load_module_strict=False
+        )
+        if load_path is None:
+            raise ValueError(f"[deepspeed] failed to resume from checkpoint {checkpoint_path}")
+    else:
+        raise ValueError(f"Can't find a valid checkpoint at {checkpoint_path}")

--- a/training/patched_hf_trainer.py
+++ b/training/patched_hf_trainer.py
@@ -1,0 +1,311 @@
+
+import os
+import random
+import warnings
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+
+
+# Integrations must be imported before ML frameworks:
+# isort: off
+from transformers.integrations import (
+    get_reporting_integration_callbacks,
+    hp_params,
+    is_fairscale_available,
+)
+
+# isort: on
+
+import numpy as np
+import torch
+import torch.distributed as dist
+from huggingface_hub import Repository, create_repo
+from packaging import version
+from torch import nn
+from torch.utils.data import DataLoader, Dataset, RandomSampler, SequentialSampler
+
+from transformers import __version__
+from transformers.configuration_utils import PretrainedConfig
+from transformers.data.data_collator import DataCollator, DataCollatorWithPadding, default_data_collator
+from transformers.debug_utils import DebugOption, DebugUnderflowOverflow
+from transformers.deepspeed import deepspeed_init, deepspeed_load_checkpoint
+from transformers.dependency_versions_check import dep_version_check
+from transformers.modelcard import TrainingSummary
+from transformers.modeling_utils import PreTrainedModel, load_sharded_checkpoint, unwrap_model
+from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES, MODEL_MAPPING_NAMES
+
+from transformers.trainer_callback import (
+    CallbackHandler,
+    DefaultFlowCallback,
+    PrinterCallback,
+    ProgressCallback,
+    TrainerCallback,
+    TrainerControl,
+    TrainerState,
+)
+from transformers.trainer_pt_utils import (
+    DistributedTensorGatherer,
+    IterableDatasetShard,
+    LabelSmoother,
+    LengthGroupedSampler,
+    SequentialDistributedSampler,
+    distributed_broadcast_scalars,
+    distributed_concat,
+    find_batch_size,
+    get_model_param_count,
+    get_module_class_from_name,
+    get_parameter_names,
+    nested_concat,
+    nested_detach,
+    nested_numpify,
+    nested_xla_mesh_reduce,
+    reissue_pt_warnings,
+)
+from transformers.trainer_utils import (
+    PREFIX_CHECKPOINT_DIR,
+    BestRun,
+    EvalLoopOutput,
+    EvalPrediction,
+    FSDPOption,
+    HPSearchBackend,
+    HubStrategy,
+    IntervalStrategy,
+    PredictionOutput,
+    RemoveColumnsCollator,
+    ShardedDDPOption,
+    TrainerMemoryTracker,
+    TrainOutput,
+    default_compute_objective,
+    denumpify_detensorize,
+    enable_full_determinism,
+    find_executable_batch_size,
+    get_last_checkpoint,
+    has_length,
+    number_of_arguments,
+    seed_worker,
+    set_seed,
+    speed_metrics,
+)
+from transformers.training_args import OptimizerNames, ParallelMode, TrainingArguments
+from transformers.utils import (
+    ADAPTER_CONFIG_NAME,
+    ADAPTER_SAFE_WEIGHTS_NAME,
+    ADAPTER_WEIGHTS_NAME,
+    CONFIG_NAME,
+    SAFE_WEIGHTS_INDEX_NAME,
+    SAFE_WEIGHTS_NAME,
+    WEIGHTS_INDEX_NAME,
+    WEIGHTS_NAME,
+    can_return_loss,
+    find_labels,
+    get_full_repo_name,
+    is_accelerate_available,
+    is_apex_available,
+    is_datasets_available,
+    is_in_notebook,
+    is_ipex_available,
+    is_peft_available,
+    is_safetensors_available,
+    is_sagemaker_dp_enabled,
+    is_sagemaker_mp_enabled,
+    is_torch_compile_available,
+    is_torch_neuroncore_available,
+    is_torch_tpu_available,
+    logging,
+    strtobool,
+)
+
+
+DEFAULT_CALLBACKS = [DefaultFlowCallback]
+DEFAULT_PROGRESS_CALLBACK = ProgressCallback
+
+
+
+if is_datasets_available():
+    import datasets
+
+if is_torch_tpu_available(check_device=False):
+    import torch_xla.core.xla_model as xm
+    import torch_xla.debug.metrics as met
+
+if is_fairscale_available():
+    dep_version_check("fairscale")
+    import fairscale
+    from fairscale.nn.data_parallel import FullyShardedDataParallel as FullyShardedDDP
+    from fairscale.nn.data_parallel import ShardedDataParallel as ShardedDDP
+    from fairscale.nn.wrap import auto_wrap
+    from fairscale.optim import OSS
+    from fairscale.optim.grad_scaler import ShardedGradScaler
+
+
+if is_sagemaker_mp_enabled():
+    import smdistributed.modelparallel.torch as smp
+    from smdistributed.modelparallel import __version__ as SMP_VERSION
+
+    IS_SAGEMAKER_MP_POST_1_10 = version.parse(SMP_VERSION) >= version.parse("1.10")
+
+    from .trainer_pt_utils import smp_forward_backward, smp_forward_only, smp_gather, smp_nested_concat
+else:
+    IS_SAGEMAKER_MP_POST_1_10 = False
+
+
+if is_safetensors_available():
+    import safetensors.torch
+
+
+if is_peft_available():
+    from peft import PeftModel
+
+
+if is_accelerate_available():
+    from accelerate import Accelerator, skip_first_batches
+    from accelerate import __version__ as accelerate_version
+    from accelerate.utils import DistributedDataParallelKwargs, GradientAccumulationPlugin
+
+    if version.parse(accelerate_version) > version.parse("0.20.3"):
+        from accelerate.utils import (
+            load_fsdp_model,
+            load_fsdp_optimizer,
+            save_fsdp_model,
+            save_fsdp_optimizer,
+        )
+
+
+logger = logging.get_logger(__name__)
+
+
+# Name of the files used for checkpointing
+TRAINING_ARGS_NAME = "training_args.bin"
+TRAINER_STATE_NAME = "trainer_state.json"
+OPTIMIZER_NAME = "optimizer.pt"
+SCHEDULER_NAME = "scheduler.pt"
+SCALER_NAME = "scaler.pt"
+
+
+from transformers import Trainer
+
+
+
+class LightweightTrainer(Trainer):
+    def _save_checkpoint(self, model, trial, metrics=None):
+        # In all cases, including ddp/dp/deepspeed, self.model is always a reference to the model we
+        # want to save except FullyShardedDDP.
+        # assert unwrap_model(model) is self.model, "internal model should be a reference to self.model"
+
+        # Save model checkpoint
+        checkpoint_folder = f"{PREFIX_CHECKPOINT_DIR}-{self.state.global_step}"
+
+        if self.hp_search_backend is None and trial is None:
+            self.store_flos()
+
+        run_dir = self._get_output_dir(trial=trial)
+        output_dir = os.path.join(run_dir, checkpoint_folder)
+        self.save_model(output_dir, _internal_call=True)
+        if self.is_deepspeed_enabled:
+            # under zero3 model file itself doesn't get saved since it's bogus! Unless deepspeed
+            # config `stage3_gather_16bit_weights_on_model_save` is True
+            print("Saving deepspeed!")
+            # comment this out and it'll only save the lora weights, but fail at return time
+            # so you can patch that (specifically _load_best_model) - OR try updating to the pre-release deepspeed
+            self.model_wrapped.save_checkpoint(output_dir, exclude_frozen_parameters=True)
+
+        # Save optimizer and scheduler
+        if self.sharded_ddp == ShardedDDPOption.SIMPLE:
+            self.optimizer.consolidate_state_dict()
+
+        if self.fsdp or self.is_fsdp_enabled:
+            if self.is_fsdp_enabled:
+                save_fsdp_optimizer(
+                    self.accelerator.state.fsdp_plugin, self.accelerator, self.optimizer, self.model, output_dir
+                )
+            else:
+                # FSDP has a different interface for saving optimizer states.
+                # Needs to be called on all ranks to gather all states.
+                # full_optim_state_dict will be deprecated after Pytorch 2.2!
+                full_osd = self.model.__class__.full_optim_state_dict(self.model, self.optimizer)
+                torch.save(full_osd, os.path.join(output_dir, OPTIMIZER_NAME))
+
+        if is_torch_tpu_available():
+            xm.rendezvous("saving_optimizer_states")
+            xm.save(self.optimizer.state_dict(), os.path.join(output_dir, OPTIMIZER_NAME))
+            with warnings.catch_warnings(record=True) as caught_warnings:
+                xm.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, SCHEDULER_NAME))
+                reissue_pt_warnings(caught_warnings)
+        elif is_sagemaker_mp_enabled():
+            opt_state_dict = self.optimizer.local_state_dict(gather_if_shard=False)
+            smp.barrier()
+            if smp.rdp_rank() == 0 or smp.state.cfg.shard_optimizer_state:
+                smp.save(
+                    opt_state_dict,
+                    os.path.join(output_dir, OPTIMIZER_NAME),
+                    partial=True,
+                    v3=smp.state.cfg.shard_optimizer_state,
+                )
+            if self.args.should_save:
+                with warnings.catch_warnings(record=True) as caught_warnings:
+                    torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, SCHEDULER_NAME))
+                reissue_pt_warnings(caught_warnings)
+                if self.do_grad_scaling:
+                    torch.save(self.scaler.state_dict(), os.path.join(output_dir, SCALER_NAME))
+        elif self.args.should_save and not self.is_deepspeed_enabled and not (self.fsdp or self.is_fsdp_enabled):
+            # deepspeed.save_checkpoint above saves model/optim/sched
+            torch.save(self.optimizer.state_dict(), os.path.join(output_dir, OPTIMIZER_NAME))
+
+            with warnings.catch_warnings(record=True) as caught_warnings:
+                torch.save(self.lr_scheduler.state_dict(), os.path.join(output_dir, SCHEDULER_NAME))
+            reissue_pt_warnings(caught_warnings)
+            if self.do_grad_scaling:
+                torch.save(self.scaler.state_dict(), os.path.join(output_dir, SCALER_NAME))
+
+        # Determine the new best metric / best model checkpoint
+        if metrics is not None and self.args.metric_for_best_model is not None:
+            metric_to_check = self.args.metric_for_best_model
+            if not metric_to_check.startswith("eval_"):
+                metric_to_check = f"eval_{metric_to_check}"
+            metric_value = metrics[metric_to_check]
+
+            operator = np.greater if self.args.greater_is_better else np.less
+            if (
+                self.state.best_metric is None
+                or self.state.best_model_checkpoint is None
+                or operator(metric_value, self.state.best_metric)
+            ):
+                self.state.best_metric = metric_value
+                self.state.best_model_checkpoint = output_dir
+
+        # Save the Trainer state
+        if self.args.should_save:
+            self.state.save_to_json(os.path.join(output_dir, TRAINER_STATE_NAME))
+
+        # Save RNG state in non-distributed training
+        rng_states = {
+            "python": random.getstate(),
+            "numpy": np.random.get_state(),
+            "cpu": torch.random.get_rng_state(),
+        }
+        if torch.cuda.is_available():
+            if self.args.parallel_mode == ParallelMode.DISTRIBUTED:
+                # In non distributed, we save the global CUDA RNG state (will take care of DataParallel)
+                rng_states["cuda"] = torch.cuda.random.get_rng_state_all()
+            else:
+                rng_states["cuda"] = torch.cuda.random.get_rng_state()
+
+        if is_torch_tpu_available():
+            rng_states["xla"] = xm.get_rng_state()
+
+        # A process can arrive here before the process 0 has a chance to save the model, in which case output_dir may
+        # not yet exist.
+        os.makedirs(output_dir, exist_ok=True)
+
+        if self.args.world_size <= 1:
+            torch.save(rng_states, os.path.join(output_dir, "rng_state.pth"))
+        else:
+            torch.save(rng_states, os.path.join(output_dir, f"rng_state_{self.args.process_index}.pth"))
+
+        if self.args.push_to_hub:
+            self._push_from_checkpoint(output_dir)
+
+        # Maybe delete some older checkpoints.
+        if self.args.should_save:
+            self._rotate_checkpoints(use_mtime=True, output_dir=run_dir)

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -11,12 +11,19 @@ import torch
 from cog import Input, Path
 from peft import (LoraConfig, get_peft_model)
 from torch.utils.data import Dataset
-from transformers import LlamaForCausalLM, Trainer, TrainingArguments, AutoConfig
+from transformers import LlamaForCausalLM, TrainingArguments, AutoConfig
 from tensorizer import TensorDeserializer
 from tensorizer.utils import no_init_or_tensor
 import sys
 sys.path.append('/src/')
+sys.path.append('/src/training/')
 
+# patching
+import transformers.deepspeed as ds
+from patched_deepspeed_checkpoint import mod_deepspeed_load_checkpoint
+ds.deepspeed_load_checkpoint = mod_deepspeed_load_checkpoint
+
+from patched_hf_trainer import LightweightTrainer as Trainer
 from config import DEFAULT_MODEL_NAME, load_tokenizer, load_tensorizer
 
 MODEL_OUT = "/src/tuned_weights.tensors"


### PR DESCRIPTION
This adds a few features to fine-tuning: 

* Saves checkpoints every n_epochs/steps
* Critically, patches the HF trainer s.t. deepspeed only saves the peft weights, instead of the entire 13/26 GB model every checkpoint.
* Returns best performing model according to eval loss 
* Automatically splits train dataset into train & eval if no eval dataset is provided using `train_test_split` input 

WIP b/c I still need to ensure the non-happy path (train_test_split=1) works. 